### PR TITLE
Fixes #382 - `_get_remote_branch_status()` should use current branch's remote

### DIFF
--- a/agentos/cli.py
+++ b/agentos/cli.py
@@ -93,6 +93,13 @@ _option_force = click.option(
     default=False,
     help="Force freeze even if repo is in a bad state.",
 )
+_option_output_file = click.option(
+    "--output-file",
+    "-o",
+    metavar="OUTPUT_FILE",
+    default=None,
+    help="Write the output to a file.",
+)
 
 
 @agentos_cmd.command()
@@ -230,7 +237,8 @@ def rerun(run_id):
 @_option_registry_file
 @_option_force
 @_option_use_venv
-def freeze(component_name, registry_file, force, use_venv):
+@_option_output_file
+def freeze(component_name, registry_file, force, use_venv, output_file):
     """
     Creates a version of ``registry_file`` for Component
     ``component_name`` where all Components in the dependency tree are
@@ -248,7 +256,11 @@ def freeze(component_name, registry_file, force, use_venv):
         registry_file, component_name, use_venv=use_venv
     )
     frozen_reg = component.to_frozen_registry(force=force)
-    print(yaml.dump(frozen_reg.to_dict()))
+    if output_file:
+        with open(output_file, "w") as f:
+            yaml.dump(frozen_reg.to_dict(), f)
+    else:
+        print(yaml.dump(frozen_reg.to_dict()))
 
 
 @agentos_cmd.command()

--- a/documentation/demos/demo_ilya_papag_from_cli.sh
+++ b/documentation/demos/demo_ilya_papag_from_cli.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
-set -x
+set -xe
 cd "$(dirname "$0")"  # cd to dir that this shell script is in.
 cd ../..  # cd to agentos root
 PAPAG_DIR=./example_agents/papag
 SB3_DIR=./example_agents/sb3_agent
 
 # Run PAPAG using Pong environment
-agentos freeze agent --registry-file $PAPAG_DIR/components.yaml > /tmp/papag-components.yaml
+agentos freeze agent --registry-file $PAPAG_DIR/components.yaml --output-file /tmp/papag-components.yaml
 agentos run agent --registry-file /tmp/papag-components.yaml --entry-point learn --arg-set-file $PAPAG_DIR/ppo_pong_args.yaml > papag_output.txt
 AGENT_RUN_ID=$(grep -Eo 'AgentRun ([0-9,a-f]+)' papag_output.txt|grep -o ' [0-9,a-f]\+')
 USE_LOCAL_SERVER=True agentos publish-run $AGENT_RUN_ID
 
 # Run SB3 using Pong environment
-agentos freeze sb3_agent --registry-file $SB3_DIR/components.yaml > /tmp/sb3-agent-components.yaml
+agentos freeze sb3_agent --registry-file $SB3_DIR/components.yaml --output-file /tmp/sb3-agent-components.yaml
 agentos run sb3_agent --registry-file /tmp/sb3-agent-components.yaml --entry-point learn --arg-set-file $SB3_DIR/ppo_pong_args.yaml > sb3_output.txt
 AGENT_RUN_ID=$(grep -Eo 'AgentRun ([0-9,a-f]+)' sb3_output.txt|grep -o ' [0-9,a-f]\+')
 USE_LOCAL_SERVER=True agentos publish-run $AGENT_RUN_ID

--- a/documentation/demos/demo_ilya_papag_from_cli.sh
+++ b/documentation/demos/demo_ilya_papag_from_cli.sh
@@ -6,8 +6,8 @@ PAPAG_DIR=./example_agents/papag
 SB3_DIR=./example_agents/sb3_agent
 
 # Run PAPAG using Pong environment
-agentos freeze agent --registry-file $PAPAG_DIR/components.yaml --output-file /tmp/papag-components.yaml
-agentos run agent --registry-file /tmp/papag-components.yaml --entry-point learn --arg-set-file $PAPAG_DIR/ppo_pong_args.yaml > papag_output.txt
+agentos freeze papag_agent --registry-file $PAPAG_DIR/components.yaml --output-file /tmp/papag-components.yaml
+agentos run papag_agent --registry-file /tmp/papag-components.yaml --entry-point learn --arg-set-file $PAPAG_DIR/ppo_pong_args.yaml > papag_output.txt
 AGENT_RUN_ID=$(grep -Eo 'AgentRun ([0-9,a-f]+)' papag_output.txt|grep -o ' [0-9,a-f]\+')
 USE_LOCAL_SERVER=True agentos publish-run $AGENT_RUN_ID
 

--- a/example_agents/papag/a2c_cartpole_args.yaml
+++ b/example_agents/papag/a2c_cartpole_args.yaml
@@ -1,7 +1,7 @@
 # https://github.com/ikostrikov/pytorch-a2c-ppo-acktr-gail#a2c with CartPole
 # python main.py --env-name "CartPole-v1"
 
-agent:
+papag_agent:
     __init__:
         env_name: CartPole-v1
         algo_name: a2c

--- a/example_agents/papag/a2c_pong_args.yaml
+++ b/example_agents/papag/a2c_pong_args.yaml
@@ -1,7 +1,7 @@
 # https://github.com/ikostrikov/pytorch-a2c-ppo-acktr-gail#a2c
 # python main.py --env-name "PongNoFrameskip-v4"
 
-agent:
+papag_agent:
     __init__:
         env_name: PongNoFrameskip-v4
         algo_name: a2c

--- a/example_agents/papag/acktr_pong_args.yaml
+++ b/example_agents/papag/acktr_pong_args.yaml
@@ -1,7 +1,7 @@
 # https://github.com/ikostrikov/pytorch-a2c-ppo-acktr-gail#acktr
 # python main.py --env-name "PongNoFrameskip-v4" --algo acktr --num-processes 32 --num-steps 20
 
-agent:
+papag_agent:
     __init__:
         env_name: PongNoFrameskip-v4
         algo_name: acktr

--- a/example_agents/papag/agent.py
+++ b/example_agents/papag/agent.py
@@ -95,7 +95,7 @@ class PAPAGAgent:
         with self.PAPAGRun.evaluate_run(
             outer_run=active_component_run(self),
             model_input_run=self.model_input_run,
-            agent_identifier=self.Algo.__component__.identifier,
+            agent_identifier=self.__component__.identifier,
             environment_identifier=env_class.__component__.identifier,
         ) as eval_run:
             torch.manual_seed(seed)
@@ -179,7 +179,7 @@ class PAPAGAgent:
         with self.PAPAGRun.learn_run(
             outer_run=active_component_run(self),
             model_input_run=self.model_input_run,
-            agent_identifier=self.Algo.__component__.identifier,
+            agent_identifier=self.__component__.identifier,
             environment_identifier=env_class.__component__.identifier,
         ) as learn_run:
             torch.manual_seed(seed)

--- a/example_agents/papag/components.yaml
+++ b/example_agents/papag/components.yaml
@@ -16,7 +16,7 @@ repos:
         url: https://github.com/mgbellemare/Arcade-Learning-Environment.git
 
 components:
-    agent:
+    papag_agent:
         repo: papag_agent_dir
         file_path: agent.py
         class_name: PAPAGAgent

--- a/example_agents/papag/ppo_cartpole_args.yaml
+++ b/example_agents/papag/ppo_cartpole_args.yaml
@@ -3,7 +3,7 @@
 
 
 
-agent:
+papag_agent:
     __init__:
         env_name: CartPole-v1
         algo_name: ppo

--- a/example_agents/papag/ppo_pong_args.yaml
+++ b/example_agents/papag/ppo_pong_args.yaml
@@ -3,7 +3,7 @@
 
 
 
-agent:
+papag_agent:
     __init__:
         env_name: PongNoFrameskip-v4
         algo_name: ppo

--- a/example_agents/sb3_agent/agent.py
+++ b/example_agents/sb3_agent/agent.py
@@ -93,7 +93,7 @@ class SB3PPOAgent:
         with self.SB3AgentRun.evaluate_run(
             outer_run=self.active_run,
             model_input_run=self.model_input_run,
-            agent_identifier=self.PPO.__component__.identifier,
+            agent_identifier=self.__component__.identifier,
             environment_identifier=env_cls.__component__.identifier,
         ) as eval_run:
             evaluate_policy(
@@ -113,7 +113,7 @@ class SB3PPOAgent:
         with self.SB3AgentRun.learn_run(
             outer_run=self.active_run,
             model_input_run=self.model_input_run,
-            agent_identifier=self.PPO.__component__.identifier,
+            agent_identifier=self.__component__.identifier,
             environment_identifier=env_cls.__component__.identifier,
         ) as learn_run:
             self.sb3_ppo.learn(

--- a/pcs/git_manager.py
+++ b/pcs/git_manager.py
@@ -133,7 +133,13 @@ class GitManager:
     def _check_for_github_url(
         self, porcelain_repo: PorcelainRepo, force: bool
     ) -> str:
-        url = self._get_remote_url(porcelain_repo, force)
+        try:
+            remote = porcelain.get_branch_remote(porcelain_repo)
+        except IndexError:
+            remote = b"origin"
+        url = self._get_remote_url(
+            porcelain_repo, force, remote=remote.decode()
+        )
         if url is None or "github.com" not in url:
             error_msg = f"Remote must be on github, not {url}"
             if force:
@@ -169,7 +175,9 @@ class GitManager:
             remote = porcelain.get_branch_remote(porcelain_repo)
         except IndexError:
             remote = b"origin"
-        url = self._get_remote_url(porcelain_repo, force, remote.decode())
+        url = self._get_remote_url(
+            porcelain_repo, force, remote=remote.decode()
+        )
         project_name, repo_name, _, _ = parse_github_web_ui_url(url)
         remote_commit_exists = self.sha1_hash_exists(
             project_name, repo_name, curr_head_hash

--- a/pcs/git_manager.py
+++ b/pcs/git_manager.py
@@ -116,9 +116,12 @@ class GitManager:
         raise BadGitStateException(error_msg)
 
     def _get_remote_url(
-        self, porcelain_repo: PorcelainRepo, force: bool
+        self,
+        porcelain_repo: PorcelainRepo,
+        force: bool,
+        remote: str = "origin"
     ) -> str:
-        url_or_path = self._get_remote_uri(porcelain_repo, force)
+        url_or_path = self._get_remote_uri(porcelain_repo, force, remote)
         # If path, assume cloned from default repo and find default repo URL.
         if Path(url_or_path).exists():
             with porcelain.open_repo_closing(url_or_path) as local_repo:

--- a/pcs/git_manager.py
+++ b/pcs/git_manager.py
@@ -162,7 +162,11 @@ class GitManager:
         self, porcelain_repo: PorcelainRepo, force: bool
     ) -> str:
         curr_head_hash = porcelain_repo.head().decode()
-        url = self._get_remote_url(porcelain_repo, force)
+        try:
+            remote = porcelain.get_branch_remote(porcelain_repo)
+        except IndexError:
+            remote = b'origin'
+        url = self._get_remote_url(porcelain_repo, force, remote.decode())
         project_name, repo_name, _, _ = parse_github_web_ui_url(url)
         remote_commit_exists = self.sha1_hash_exists(
             project_name, repo_name, curr_head_hash

--- a/pcs/git_manager.py
+++ b/pcs/git_manager.py
@@ -119,7 +119,7 @@ class GitManager:
         self,
         porcelain_repo: PorcelainRepo,
         force: bool,
-        remote: str = "origin"
+        remote: str = "origin",
     ) -> str:
         url_or_path = self._get_remote_uri(porcelain_repo, force, remote)
         # If path, assume cloned from default repo and find default repo URL.
@@ -168,7 +168,7 @@ class GitManager:
         try:
             remote = porcelain.get_branch_remote(porcelain_repo)
         except IndexError:
-            remote = b'origin'
+            remote = b"origin"
         url = self._get_remote_url(porcelain_repo, force, remote.decode())
         project_name, repo_name, _, _ = parse_github_web_ui_url(url)
         remote_commit_exists = self.sha1_hash_exists(

--- a/tests/example_agents/test_papag.py
+++ b/tests/example_agents/test_papag.py
@@ -3,7 +3,7 @@ from tests.utils import PAPAG_AGENT_DIR, run_test_command
 
 # Use CartPole because Atari ROM licensing issues break tests on Windows.
 test_args = [
-    "agent",
+    "papag_agent",
     "--use-outer-env",
     "-Anum_env_steps=1",
     "-Anum_processes=1",


### PR DESCRIPTION
* Fixes #382
* Fixes #383
* Fixes #384

`_get_remote_branch_status()` should use current branch's remote if the repo is on a branch currently instead of always using the 'origin' remote